### PR TITLE
ci: throttle Dependabot to monthly grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    # Group all npm updates into a single PR per cycle to avoid the
+    # per-package PR explosion (~daily runs on default config).
+    groups:
+      all-deps:
+        patterns:
+          - "*"
+    # Only one open Dependabot PR at a time — if it's stale, close it
+    # and the next cycle will open a fresh one with current versions.
+    open-pull-requests-limit: 1


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to throttle Dependabot from its current unthrottled cadence (~daily runs, ~74% failure rate) to a single monthly grouped PR.

**Current state:**
- 128 total Dependabot Updates runs in Actions history
- 95 failures (74% failure rate)
- Same packages (lodash, path-to-regexp, yaml, serialize-javascript) retrying repeatedly because the old eslint/webpack toolchain can't cleanly bump them
- No existing dependabot.yml \u2014 running on default config

**Config:**
- Monthly cadence
- All npm updates grouped into one PR
- Max 1 open Dependabot PR at a time

## Expected impact

~20\u201330x reduction in Dependabot runs for this repo. Security updates (filed automatically from Dependabot vulnerability alerts) are separate from version updates and remain enabled via repo settings.

## Test plan

- [ ] Verify `.github/dependabot.yml` syntax (GitHub validates on merge)
- [ ] After merge, confirm Dependabot schedule in repo Insights \u2192 Dependency graph \u2192 Dependabot shows monthly
- [ ] Next month: verify only one grouped PR appears instead of many per-package PRs